### PR TITLE
Add Error for use of unknown MediaQuery

### DIFF
--- a/utils/mixin/_respond-to.scss
+++ b/utils/mixin/_respond-to.scss
@@ -8,5 +8,8 @@
 		@media #{map-get($mediaQueries, $name)} {
 			@content;
 		}
+	} @else {
+    	@error "MediaQuery #{$name} does not exist";
 	}
+  }
 }


### PR DESCRIPTION
This PR will let the respond-to mixin throw an error when a not existing list item is used.

edit: description added