### PR TITLE
Add function for remify, fluid and fluid-font

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ $ npm i -S seng-scss
     - **$mediaQueries**: default list of mediaQueries (empty list)
     - **$minimumFluidTypeViewportWidth**: default value for minimum viewport width used in fluid type (480px)
     - **$maximumFluidTypeViewportWidth**: default value for maximum viewport width used in fluid type (1440px)
+    - **$baseFontSizeValue**: default value (16) use for calculation in remify function
     - **$minimumFluidValueViewportWidth**: default value (375px) for the use with fluid and fluid-font used to scale from
     - **$maximumFluidValueViewportWidth**: default value (1920px) for the use with fluid and fluid-font used to scale to
     - **$ease{name}**: List of easing bezier curves

--- a/README.md
+++ b/README.md
@@ -52,11 +52,9 @@ $ npm i -S seng-scss
     - **$pathImage**: default project image path (image, prefixed with $pathAsset)
     - **$zLayout**: default list of zIndex names (default)\*\*
     - **$mediaQueries**: default list of mediaQueries (empty list)
-    - **$minimumFluidTypeViewportWidth**: default value for minimum viewport width used in fluid type (480px)
-    - **$maximumFluidTypeViewportWidth**: default value for maximum viewport width used in fluid type (1440px)
     - **$baseFontSizeValue**: default value (16) use for calculation in remify function
-    - **$minimumFluidValueViewportWidth**: default value (375px) for the use with fluid and fluid-font used to scale from
-    - **$maximumFluidValueViewportWidth**: default value (1920px) for the use with fluid and fluid-font used to scale to
+    - **$minimumFluidValueViewportWidth**: default value for minimum viewport width used in fluid type (480px)
+    - **$maximumFluidValueViewportWidth**: default value for maximum viewport width used in fluid type (1440px)
     - **$ease{name}**: List of easing bezier curves
         -   **$easeLinear**
             -   **$ease**

--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ A SCSS library of mixins and functions that are used within projects.
 
 ## Installation
 
-### npm
-
-```sh
-npm i -S seng-scss
+```shell
+$ yarn add -D seng-scss
+```
+or
+```shell
+$ npm i -S seng-scss
 ```
 
 ## Included functionalities
@@ -38,18 +40,23 @@ npm i -S seng-scss
 -   [em-size](./utils/function/_em-size.scss)
 -   [font-weight](./utils/function/_font-weight.scss)
 -   [strip-unit](./utils/function/_strip-unit.scss)
+-   [remify](./utils/function/_remify.scss)
+-   [fluid](./utils/function/_fluid.scss)
+-   [fluid-font](./utils/function/_fluid-font.scss)
 
 ### Variables
 
 -   [variables](./utils/_variables.scss)
-    -   **$pathAsset**: default project asset path (..)
-    -   **$pathFont**: default project font path (font, prefixed with $pathAsset)
-    -   **$pathImage**: default project image path (image, prefixed with $pathAsset)
-    -   **$zLayout**: default list of zIndex names (default)\*\*
-    -   **$mediaQueries**: default list of mediaQueries (empty list)
-    -   **$minimumFluidTypeViewportWidth**: default value for minumum viewport width used in fluid type (480px)
-    -   **$maximumFluidTypeViewportWidth**: default value for maximum viewport width used in fluid type (1440px)
-    -   **$ease{name}**: List of easing bezier curves
+    - **$pathAsset**: default project asset path (..)
+    - **$pathFont**: default project font path (font, prefixed with $pathAsset)
+    - **$pathImage**: default project image path (image, prefixed with $pathAsset)
+    - **$zLayout**: default list of zIndex names (default)\*\*
+    - **$mediaQueries**: default list of mediaQueries (empty list)
+    - **$minimumFluidTypeViewportWidth**: default value for minimum viewport width used in fluid type (480px)
+    - **$maximumFluidTypeViewportWidth**: default value for maximum viewport width used in fluid type (1440px)
+    - **$minVW**: default value (375px) for the use with fluid and fluid-font used to scale from
+    - **$maxVW**: default value (1920px) for the use with fluid and fluid-font used to scale to
+    - **$ease{name}**: List of easing bezier curves
         -   **$easeLinear**
             -   **$ease**
             -   **$easeIn**
@@ -79,6 +86,7 @@ npm i -S seng-scss
             -   **$easeInOutExpo**
             -   **$easeInOutCirc**
             -   **$easeInOutBack**
+  
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ $ npm i -S seng-scss
     - **$mediaQueries**: default list of mediaQueries (empty list)
     - **$minimumFluidTypeViewportWidth**: default value for minimum viewport width used in fluid type (480px)
     - **$maximumFluidTypeViewportWidth**: default value for maximum viewport width used in fluid type (1440px)
-    - **$minVW**: default value (375px) for the use with fluid and fluid-font used to scale from
-    - **$maxVW**: default value (1920px) for the use with fluid and fluid-font used to scale to
+    - **$minimumFluidValueViewportWidth**: default value (375px) for the use with fluid and fluid-font used to scale from
+    - **$maximumFluidValueViewportWidth**: default value (1920px) for the use with fluid and fluid-font used to scale to
     - **$ease{name}**: List of easing bezier curves
         -   **$easeLinear**
             -   **$ease**

--- a/base.scss
+++ b/base.scss
@@ -5,6 +5,9 @@
 @import 'utils/function/em-size';
 @import 'utils/function/font-weight';
 @import 'utils/function/strip-unit';
+@import 'utils/function/remify';
+@import 'utils/function/fluid';
+@import 'utils/function/fluid-font';
 
 @import 'utils/mixin/aspect-ratio';
 @import 'utils/mixin/font-face';

--- a/utils/_variables.scss
+++ b/utils/_variables.scss
@@ -3,8 +3,6 @@ $pathAsset: ".." !default;
 $pathFont: "font" !default;
 $pathImage: "image" !default;
 
-$baseFontSizeValue: 16 !default;
-
 // Z-Index
 $zLayout: default !default;
 
@@ -57,5 +55,6 @@ $minimumFluidTypeViewportWidth: 480px !default;
 $maximumFluidTypeViewportWidth: 1440px !default;
 
 // Fluid value sizes
+$baseFontSizeValue: 16 !default;
 $minimumFluidValueViewportWidth: 375px !default;
 $maximumFluidValueViewportWidth: 1920px !default;

--- a/utils/_variables.scss
+++ b/utils/_variables.scss
@@ -3,7 +3,7 @@ $pathAsset: ".." !default;
 $pathFont: "font" !default;
 $pathImage: "image" !default;
 
-$baseFontSizeValue: 16;
+$baseFontSizeValue: 16 !default;
 
 // Z-Index
 $zLayout: default !default;

--- a/utils/_variables.scss
+++ b/utils/_variables.scss
@@ -55,5 +55,5 @@ $minimumFluidTypeViewportWidth: 480px !default;
 $maximumFluidTypeViewportWidth: 1440px !default;
 
 // Fluid value sizes
-$minVW: 375px !default;
-$maxVW: 1920px !default;
+$minimumFluidValueViewportWidth: 375px !default;
+$maximumFluidValueViewportWidth: 1920px !default;

--- a/utils/_variables.scss
+++ b/utils/_variables.scss
@@ -3,6 +3,8 @@ $pathAsset: ".." !default;
 $pathFont: "font" !default;
 $pathImage: "image" !default;
 
+$baseFontSizeValue: 16;
+
 // Z-Index
 $zLayout: default !default;
 

--- a/utils/_variables.scss
+++ b/utils/_variables.scss
@@ -53,3 +53,7 @@ $easeInOutBack: cubic-bezier(0.68, -0.55, 0.265, 1.55);
 // Fluid type
 $minimumFluidTypeViewportWidth: 480px !default;
 $maximumFluidTypeViewportWidth: 1440px !default;
+
+// Fluid value sizes
+$minVW: 375px !default;
+$maxVW: 1920px !default;

--- a/utils/_variables.scss
+++ b/utils/_variables.scss
@@ -50,11 +50,7 @@ $easeInOutExpo: cubic-bezier(1, 0, 0, 1);
 $easeInOutCirc: cubic-bezier(0.785, 0.135, 0.15, 0.86);
 $easeInOutBack: cubic-bezier(0.68, -0.55, 0.265, 1.55);
 
-// Fluid type
-$minimumFluidTypeViewportWidth: 480px !default;
-$maximumFluidTypeViewportWidth: 1440px !default;
-
-// Fluid value sizes
+// Fluid values
 $baseFontSizeValue: 16 !default;
-$minimumFluidValueViewportWidth: 375px !default;
-$maximumFluidValueViewportWidth: 1920px !default;
+$minimumFluidValueViewportWidth: 480px !default;
+$maximumFluidValueViewportWidth: 1440px !default;

--- a/utils/function/_fluid-font.scss
+++ b/utils/function/_fluid-font.scss
@@ -5,12 +5,12 @@
  * This function will remify the values by default
  */
 
-@function fluid-font($minValue, $maxValue, $minViewportWidth: $minVW, $maxViewportWidth: $maxVW) {
+@function fluid-font($minValue, $maxValue, $minViewportWidth: $minimumFluidValueViewportWidth, $maxViewportWidth: $maximumFluidValueViewportWidth) {
   @return fluid(
     $minValue,
     $maxValue,
-    $minViewportWidth: $minVW,
-    $maxViewportWidth: $maxVW,
+    $minViewportWidth: $minimumFluidValueViewportWidth,
+    $maxViewportWidth: $maximumFluidValueViewportWidth,
     $remify: true
   );
 }

--- a/utils/function/_fluid-font.scss
+++ b/utils/function/_fluid-font.scss
@@ -1,0 +1,16 @@
+@import "../variables", "fluid";
+
+/*
+ * See fluid for usage
+ * This function will remify the values by default
+ */
+
+@function fluid-font($minValue, $maxValue, $minViewportWidth: $minVW, $maxViewportWidth: $maxVW) {
+  @return fluid(
+    $minValue,
+    $maxValue,
+    $minViewportWidth: $minVW,
+    $maxViewportWidth: $maxVW,
+    $remify: true
+  );
+}

--- a/utils/function/_fluid.scss
+++ b/utils/function/_fluid.scss
@@ -1,0 +1,38 @@
+@import "../variables", "remify", "strip-unit";
+
+/*
+ * This function will return a fluid value between two viewport size
+ * The value will linear scale from the start value to the end value
+ * This makes it possible to scale from a larger to smaller number with an increasing vw
+ * The $minViewportWidth and the $maxViewportWidth will allow a value to clamp between values
+ * This means: below the $maxViewportWidth the value will be $startValue and not smaller/bigger
+ * By default the variables $minVW and $maxVW or used but it is possible to use different sizes
+ * It's possible to return rem units (but there is debate on whether values other than font-sizes should be rem)
+ * For font-sizes there is a fluid-font function that uses rems!
+ */
+
+@function fluid(
+  $startValue,
+  $endValue,
+  $minViewportWidth: $minVW,
+  $maxViewportWidth: $maxVW,
+  $remify: false
+) {
+  $minValue: $startValue;
+  $maxValue: $endValue;
+
+  @if $endValue < $startValue {
+    $minValue: $endValue;
+    $maxValue: $startValue;
+  }
+
+  $additionalSize: #{strip-unit($minViewportWidth) / 100}px;
+  $startSize: remify($startValue, $remify);
+  $endSize: remify($endValue, $remify);
+  $calc: #{calc(
+      #{$startSize} + ((#{1vw} - #{$additionalSize}) * #{100 * ($endValue - $startValue) /
+            ($maxViewportWidth - $minVW)})
+    )};
+
+  @return clamp(#{remify($minValue, $remify)}, #{$calc}, #{remify($maxValue, $remify)});
+}

--- a/utils/function/_fluid.scss
+++ b/utils/function/_fluid.scss
@@ -6,7 +6,7 @@
  * This makes it possible to scale from a larger to smaller number with an increasing vw
  * The $minViewportWidth and the $maxViewportWidth will allow a value to clamp between values
  * This means: below the $maxViewportWidth the value will be $startValue and not smaller/bigger
- * By default the variables $minVW and $maxVW or used but it is possible to use different sizes
+ * By default the variables $minimumFluidValueViewportWidth and $maximumFluidValueViewportWidth or used but it is possible to use different sizes
  * It's possible to return rem units (but there is debate on whether values other than font-sizes should be rem)
  * For font-sizes there is a fluid-font function that uses rems!
  */
@@ -14,8 +14,8 @@
 @function fluid(
   $startValue,
   $endValue,
-  $minViewportWidth: $minVW,
-  $maxViewportWidth: $maxVW,
+  $minViewportWidth: $minimumFluidValueViewportWidth,
+  $maxViewportWidth: $maximumFluidValueViewportWidth,
   $remify: false
 ) {
   $minValue: $startValue;
@@ -31,7 +31,7 @@
   $endSize: remify($endValue, $remify);
   $calc: #{calc(
       #{$startSize} + ((#{1vw} - #{$additionalSize}) * #{100 * ($endValue - $startValue) /
-            ($maxViewportWidth - $minVW)})
+            ($maxViewportWidth - $minimumFluidValueViewportWidth)})
     )};
 
   @return clamp(#{remify($minValue, $remify)}, #{$calc}, #{remify($maxValue, $remify)});

--- a/utils/function/_remify.scss
+++ b/utils/function/_remify.scss
@@ -5,7 +5,7 @@
  */
 @function remify($value, $remify: true) {
   @if $remify {
-    @return #{strip-unit($value) / 16}rem;
+    @return #{strip-unit($value) / $baseFontSizeValue}rem;
   }
   @return $value;
 }

--- a/utils/function/_remify.scss
+++ b/utils/function/_remify.scss
@@ -1,0 +1,11 @@
+@import "strip-unit";
+/*
+ * Function to turn a pixel value into a rem value based on the base font-size being 16
+ * the second param seems a bit redundant but is used for fluid and fluid-fonts
+ */
+@function remify($value, $remify: true) {
+  @if $remify {
+    @return #{strip-unit($value) / 16}rem;
+  }
+  @return $value;
+}

--- a/utils/mixin/_fluid-type.scss
+++ b/utils/mixin/_fluid-type.scss
@@ -10,8 +10,8 @@
 @mixin fluid-type(
   $min-font-size,
   $max-font-size,
-  $min-vw: $minimumFluidTypeViewportWidth,
-  $max-vw: $maximumFluidTypeViewportWidth
+  $min-vw: $minimumFluidValueViewportWidth,
+  $max-vw: $maximumFluidValueViewportWidth
 ) {
   $u1: unit($min-vw);
   $u2: unit($max-vw);

--- a/utils/mixin/_respond-to.scss
+++ b/utils/mixin/_respond-to.scss
@@ -1,4 +1,4 @@
-/**
+§/**
  * Respond To (Breakpoint)
  *
  * @param {string} $name - Name of the breakpoint used in $breakpoints


### PR DESCRIPTION
I've been using these functions to create fluid font-sizes and dimensions and with clamp being supported it feels like they should be part of seng-scss. The remify is currently opiniated to have a root font-size of 100% instead of 62.5%. But the goal of the 62.5% was for calculation means to begin with. And with the remify function this becomes easy.